### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,18 +12,18 @@ IVSense	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-getCurrent KEYWORD2
-getVoltage KEYWORD2
-readData KEYWORD2
+getCurrent	KEYWORD2
+getVoltage	KEYWORD2
+readData	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)
 #######################################
 
-_ipin KEYWORD2
-_vpin KEYWORD2
-voltage KEYWORD2
-current KEYWORD2
+_ipin	KEYWORD2
+_vpin	KEYWORD2
+voltage	KEYWORD2
+current	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords